### PR TITLE
Don't need an `if` if condition is the ret-value

### DIFF
--- a/assignment/utils/__init__.py
+++ b/assignment/utils/__init__.py
@@ -8,7 +8,7 @@ import logging
 
 logger = logging.getLogger() # root logger
 
-_debug = True if logger.getEffectiveLevel() <= logging.DEBUG else False
+_debug = logger.getEffectiveLevel() <= logging.DEBUG
 
 def time_me(func):
     @wraps(func)


### PR DESCRIPTION
This is one of my pet-peeves. I don't like the pattern

```
if condition:
    return True
return False
```

Since it is exactly the same as

```
return condition
```